### PR TITLE
Add Court Availability Page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.formatOnSave": false,
-  "typescript.tsdk": "node_modules\\typescript\\lib",
+  "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "always"

--- a/components.json
+++ b/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/app/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@formkit/tempo": "^0.1.2",
+    "@radix-ui/react-slot": "^1.1.2",
+    "@radix-ui/react-tabs": "^1.1.3",
     "@tailwindcss/postcss": "^4.0.12",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -11,12 +11,17 @@
   "dependencies": {
     "@formkit/tempo": "^0.1.2",
     "@tailwindcss/postcss": "^4.0.12",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.485.0",
     "next": "15.2.0-canary.64",
     "postcss": "^8.5.3",
     "react": "19.0.0",
     "react-dom": "19.0.0",
+    "tailwind-merge": "^3.0.2",
     "tailwindcss": "^4.0.12",
     "tailwindcss-animate": "^1.0.7",
+    "tw-animate-css": "^1.2.5",
     "tweetnacl": "^1.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@formkit/tempo": "^0.1.2",
+    "@radix-ui/react-label": "^2.1.2",
+    "@radix-ui/react-radio-group": "^1.2.3",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-tabs": "^1.1.3",
     "@tailwindcss/postcss": "^4.0.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,15 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.0.12
         version: 4.0.12
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^0.485.0
+        version: 0.485.0(react@19.0.0)
       next:
         specifier: 15.2.0-canary.64
         version: 15.2.0-canary.64(@babel/core@7.24.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.0.0-beta-21e868a-20250216)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -26,12 +35,18 @@ importers:
       react-dom:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
+      tailwind-merge:
+        specifier: ^3.0.2
+        version: 3.0.2
       tailwindcss:
         specifier: ^4.0.12
         version: 4.0.12
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.0.12)
+      tw-animate-css:
+        specifier: ^1.2.5
+        version: 1.2.5
       tweetnacl:
         specifier: ^1.0.3
         version: 1.0.3
@@ -1020,12 +1035,19 @@ packages:
     resolution: {integrity: sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==}
     engines: {node: '>=8'}
 
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
   clean-regexp@1.0.0:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
     engines: {node: '>=4'}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -2016,6 +2038,11 @@ packages:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
 
+  lucide-react@0.485.0:
+    resolution: {integrity: sha512-NvyQJ0LKyyCxL23nPKESlr/jmz8r7fJO1bkuptSNYSy0s8VVj4ojhX0YAgmE1e0ewfxUZjIlZpvH+otfTnla8Q==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2554,6 +2581,9 @@ packages:
     resolution: {integrity: sha512-7gr8p9TQP6RAHusBOSLs46F4564ZrjV8xFmw5zCmgmhGUcw2hxsShhJ6CEiHQMgPDwAQ1fWHPM0ypc4RMAig4A==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  tailwind-merge@3.0.2:
+    resolution: {integrity: sha512-l7z+OYZ7mu3DTqrL88RiKrKIqO3NcpEO8V/Od04bNpvk0kiIFndGEoqfuzvj4yuhRkHKjRkII2z+KS2HfPcSxw==}
+
   tailwindcss-animate@1.0.7:
     resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
     peerDependencies:
@@ -2603,6 +2633,9 @@ packages:
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+
+  tw-animate-css@1.2.5:
+    resolution: {integrity: sha512-ABzjfgVo+fDbhRREGL4KQZUqqdPgvc5zVrLyeW9/6mVqvaDepXc7EvedA+pYmMnIOsUAQMwcWzNvom26J2qYvQ==}
 
   tweetnacl@1.0.3:
     resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
@@ -3764,11 +3797,17 @@ snapshots:
 
   ci-info@4.0.0: {}
 
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
   clean-regexp@1.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
 
   client-only@0.0.1: {}
+
+  clsx@2.1.1: {}
 
   color-convert@1.9.3:
     dependencies:
@@ -5047,6 +5086,10 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
+  lucide-react@0.485.0(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+
   math-intrinsics@1.1.0: {}
 
   merge2@1.4.1: {}
@@ -5627,6 +5670,8 @@ snapshots:
       '@pkgr/core': 0.1.0
       tslib: 2.8.1
 
+  tailwind-merge@3.0.2: {}
+
   tailwindcss-animate@1.0.7(tailwindcss@4.0.12):
     dependencies:
       tailwindcss: 4.0.12
@@ -5666,6 +5711,8 @@ snapshots:
     dependencies:
       tslib: 1.14.1
       typescript: 5.7.3
+
+  tw-animate-css@1.2.5: {}
 
   tweetnacl@1.0.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@formkit/tempo':
         specifier: ^0.1.2
         version: 0.1.2
+      '@radix-ui/react-slot':
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react@19.0.9)(react@19.0.0)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.3
+        version: 1.1.3(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tailwindcss/postcss':
         specifier: ^4.0.12
         version: 4.0.12
@@ -604,6 +610,146 @@ packages:
   '@pkgr/core@0.1.0':
     resolution: {integrity: sha512-Zwq5OCzuwJC2jwqmpEQt7Ds1DTi6BWSwoGkbb1n9pO3hzb35BoJELx7c0T23iDkBGkh2e7tvOtjF3tr3OaQHDQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@radix-ui/primitive@1.1.1':
+    resolution: {integrity: sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==}
+
+  '@radix-ui/react-collection@1.1.2':
+    resolution: {integrity: sha512-9z54IEKRxIa9VityapoEYMuByaG42iSy1ZXlY2KcuLSEtq8x4987/N6m15ppoMffgZX72gER2uHe1D9Y6Unlcw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.1':
+    resolution: {integrity: sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.1':
+    resolution: {integrity: sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.0':
+    resolution: {integrity: sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-id@1.1.0':
+    resolution: {integrity: sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.2':
+    resolution: {integrity: sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.0.2':
+    resolution: {integrity: sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.2':
+    resolution: {integrity: sha512-zgMQWkNO169GtGqRvYrzb0Zf8NhMHS2DuEB/TiEmVnpr5OqPU3i8lfbxaAmC2J/KYuIQxyoQQ6DxepyXp61/xw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.1.2':
+    resolution: {integrity: sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.3':
+    resolution: {integrity: sha512-9mFyI30cuRDImbmFF6O2KUJdgEOsGh9Vmx9x/Dh9tOhL7BngmQPQfwW4aejKm5OHpfWIdmeV6ySyuxoOGjtNng==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.0':
+    resolution: {integrity: sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.1.0':
+    resolution: {integrity: sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.0':
+    resolution: {integrity: sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -3256,6 +3402,123 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.1.0': {}
+
+  '@radix-ui/primitive@1.1.1': {}
+
+  '@radix-ui/react-collection@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.9)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.9)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot': 1.1.2(@types/react@19.0.9)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.9
+      '@types/react-dom': 19.0.3(@types/react@19.0.9)
+
+  '@radix-ui/react-compose-refs@1.1.1(@types/react@19.0.9)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.9
+
+  '@radix-ui/react-context@1.1.1(@types/react@19.0.9)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.9
+
+  '@radix-ui/react-direction@1.1.0(@types/react@19.0.9)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.9
+
+  '@radix-ui/react-id@1.1.0(@types/react@19.0.9)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.9)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.9
+
+  '@radix-ui/react-presence@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.9)(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.9)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.9
+      '@types/react-dom': 19.0.3(@types/react@19.0.9)
+
+  '@radix-ui/react-primitive@2.0.2(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.1.2(@types/react@19.0.9)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.9
+      '@types/react-dom': 19.0.3(@types/react@19.0.9)
+
+  '@radix-ui/react-roving-focus@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-collection': 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.9)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.9)(react@19.0.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@19.0.9)(react@19.0.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@19.0.9)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.9)(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.0.9)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.9
+      '@types/react-dom': 19.0.3(@types/react@19.0.9)
+
+  '@radix-ui/react-slot@1.1.2(@types/react@19.0.9)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.9)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.9
+
+  '@radix-ui/react-tabs@1.1.3(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.9)(react@19.0.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@19.0.9)(react@19.0.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@19.0.9)(react@19.0.0)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-roving-focus': 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.0.9)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.9
+      '@types/react-dom': 19.0.3(@types/react@19.0.9)
+
+  '@radix-ui/react-use-callback-ref@1.1.0(@types/react@19.0.9)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.9
+
+  '@radix-ui/react-use-controllable-state@1.1.0(@types/react@19.0.9)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.9)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.9
+
+  '@radix-ui/react-use-layout-effect@1.1.0(@types/react@19.0.9)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.9
 
   '@rtsao/scc@1.1.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@formkit/tempo':
         specifier: ^0.1.2
         version: 0.1.2
+      '@radix-ui/react-label':
+        specifier: ^2.1.2
+        version: 2.1.2(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-radio-group':
+        specifier: ^1.2.3
+        version: 1.2.3(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-slot':
         specifier: ^1.1.2
         version: 1.1.2(@types/react@19.0.9)(react@19.0.0)
@@ -663,6 +669,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-label@2.1.2':
+    resolution: {integrity: sha512-zo1uGMTaNlHehDyFQcDZXRJhUPDuukcnHz0/jnrup0JA6qL+AFpAnty+7VKa9esuU5xTblAZzTGYJKSKaBxBhw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-presence@1.1.2':
     resolution: {integrity: sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==}
     peerDependencies:
@@ -678,6 +697,19 @@ packages:
 
   '@radix-ui/react-primitive@2.0.2':
     resolution: {integrity: sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.2.3':
+    resolution: {integrity: sha512-xtCsqt8Rp09FK50ItqEqTJ7Sxanz8EM8dnkVIhJrc/wkMMomSmXHvYbhv3E7Zx4oXh98aaLt9W679SUYXg4IDA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -744,6 +776,24 @@ packages:
 
   '@radix-ui/react-use-layout-effect@1.1.0':
     resolution: {integrity: sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.0':
+    resolution: {integrity: sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.0':
+    resolution: {integrity: sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -3442,6 +3492,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.9
 
+  '@radix-ui/react-label@2.1.2(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.9
+      '@types/react-dom': 19.0.3(@types/react@19.0.9)
+
   '@radix-ui/react-presence@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.9)(react@19.0.0)
@@ -3455,6 +3514,24 @@ snapshots:
   '@radix-ui/react-primitive@2.0.2(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/react-slot': 1.1.2(@types/react@19.0.9)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.9
+      '@types/react-dom': 19.0.3(@types/react@19.0.9)
+
+  '@radix-ui/react-radio-group@1.2.3(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.9)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.9)(react@19.0.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@19.0.9)(react@19.0.0)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-roving-focus': 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.9))(@types/react@19.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.0.9)(react@19.0.0)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@19.0.9)(react@19.0.0)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@19.0.9)(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
@@ -3516,6 +3593,19 @@ snapshots:
 
   '@radix-ui/react-use-layout-effect@1.1.0(@types/react@19.0.9)(react@19.0.0)':
     dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.9
+
+  '@radix-ui/react-use-previous@1.1.0(@types/react@19.0.9)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.9
+
+  '@radix-ui/react-use-size@1.1.0(@types/react@19.0.9)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.9)(react@19.0.0)
       react: 19.0.0
     optionalDependencies:
       '@types/react': 19.0.9

--- a/src/app/availability/components/CourtsAvailability/index.tsx
+++ b/src/app/availability/components/CourtsAvailability/index.tsx
@@ -4,7 +4,8 @@ import {useSearchParams} from "next/navigation";
 
 import {FacilityCard} from "../FacilityCard";
 
-import {Badge} from "@/components/ui/badge";
+import {RadioGroup, RadioGroupItem} from "@/components/ui/radio-group";
+import {Label} from "@/components/ui/label";
 import {TabsContent} from "@/components/ui/tabs";
 import {LocationWithCourts} from "@/lib/atc";
 import {formatDate} from "@/lib/dates";
@@ -29,29 +30,48 @@ function FacilitySelector({
     const searchParams = new URLSearchParams(window.location.search);
 
     searchParams.set("facility", facility);
-
     history.pushState(null, "", `/availability?${searchParams.toString()}`);
   };
 
   return (
     <div className="flex flex-col items-start gap-6">
-      <div className="flex justify-center gap-4">
-        <Badge
-          className={`cursor-pointer px-4 py-2 ${selectedFacility === "all" ? "bg-primary" : "bg-secondary"}`}
-          onClick={() => handleFacilityClick("all")}
-        >
-          All Facilities
-        </Badge>
-        {Array.from(facilities).map((facility) => (
-          <Badge
-            key={facility}
-            className={`cursor-pointer px-4 py-2 ${selectedFacility === facility ? "bg-primary" : "bg-secondary"}`}
-            onClick={() => handleFacilityClick(facility)}
-          >
-            {facility}
-          </Badge>
-        ))}
-      </div>
+      <RadioGroup
+        className="flex justify-center gap-4"
+        defaultValue={selectedFacility}
+        onValueChange={handleFacilityClick}
+      >
+        <div className="flex flex-wrap justify-center gap-4">
+          <div className="relative">
+            <RadioGroupItem className="peer sr-only" id="all" value="all" />
+            <Label
+              className={`cursor-pointer rounded-full px-4 py-2 transition-all ${
+                selectedFacility === "all"
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-secondary text-secondary-foreground"
+              } peer-focus-visible:ring-primary peer-focus-visible:ring-2 peer-focus-visible:ring-offset-2 peer-focus-visible:outline-none`}
+              htmlFor="all"
+            >
+              All Facilities
+            </Label>
+          </div>
+
+          {Array.from(facilities).map((facility) => (
+            <div key={facility} className="relative">
+              <RadioGroupItem className="peer sr-only" id={facility} value={facility} />
+              <Label
+                className={`cursor-pointer rounded-full px-4 py-2 transition-all ${
+                  selectedFacility === facility
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-secondary text-secondary-foreground"
+                } peer-focus-visible:ring-primary peer-focus-visible:ring-2 peer-focus-visible:ring-offset-2 peer-focus-visible:outline-none`}
+                htmlFor={facility}
+              >
+                {facility}
+              </Label>
+            </div>
+          ))}
+        </div>
+      </RadioGroup>
     </div>
   );
 }

--- a/src/app/availability/components/CourtsAvailability/index.tsx
+++ b/src/app/availability/components/CourtsAvailability/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import {useState} from "react";
+import {useSearchParams} from "next/navigation";
 
 import {FacilityCard} from "../FacilityCard";
 
@@ -21,18 +21,24 @@ interface CourtsAvailabilityProps {
 function FacilitySelector({
   facilities,
   selectedFacility,
-  setSelectedFacility,
 }: {
   facilities: Set<string>;
   selectedFacility: string;
-  setSelectedFacility: (facility: string) => void;
 }) {
+  const handleFacilityClick = (facility: string) => {
+    const searchParams = new URLSearchParams(window.location.search);
+
+    searchParams.set("facility", facility);
+
+    history.pushState(null, "", `/availability?${searchParams.toString()}`);
+  };
+
   return (
     <div className="flex flex-col items-start gap-6">
       <div className="flex justify-center gap-4">
         <Badge
           className={`cursor-pointer px-4 py-2 ${selectedFacility === "all" ? "bg-primary" : "bg-secondary"}`}
-          onClick={() => setSelectedFacility("all")}
+          onClick={() => handleFacilityClick("all")}
         >
           All Facilities
         </Badge>
@@ -40,7 +46,7 @@ function FacilitySelector({
           <Badge
             key={facility}
             className={`cursor-pointer px-4 py-2 ${selectedFacility === facility ? "bg-primary" : "bg-secondary"}`}
-            onClick={() => setSelectedFacility(facility)}
+            onClick={() => handleFacilityClick(facility)}
           >
             {facility}
           </Badge>
@@ -51,17 +57,15 @@ function FacilitySelector({
 }
 
 export function CourtsAvailability({data}: CourtsAvailabilityProps) {
-  const [selectedFacility, setSelectedFacility] = useState<string>("all");
+  const searchParams = useSearchParams();
+
+  const selectedFacility = searchParams.get("facility") || "all";
 
   const facilities = new Set(data.flatMap((day) => day.locations.map((location) => location.name)));
 
   return (
     <>
-      <FacilitySelector
-        facilities={facilities}
-        selectedFacility={selectedFacility}
-        setSelectedFacility={setSelectedFacility}
-      />
+      <FacilitySelector facilities={facilities} selectedFacility={selectedFacility} />
 
       {data.map((day) => (
         <TabsContent key={formatDate(day.date)} className="w-full" value={formatDate(day.date)}>

--- a/src/app/availability/components/CourtsAvailability/index.tsx
+++ b/src/app/availability/components/CourtsAvailability/index.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import {useState} from "react";
+
+import {FacilityCard} from "../FacilityCard";
+
+import {Badge} from "@/components/ui/badge";
+import {TabsContent} from "@/components/ui/tabs";
+import {LocationWithCourts} from "@/lib/atc";
+import {formatDate} from "@/lib/dates";
+
+type DayData = {
+  date: Date;
+  locations: LocationWithCourts[];
+};
+
+interface CourtsAvailabilityProps {
+  data: DayData[];
+}
+
+function FacilitySelector({
+  facilities,
+  selectedFacility,
+  setSelectedFacility,
+}: {
+  facilities: Set<string>;
+  selectedFacility: string;
+  setSelectedFacility: (facility: string) => void;
+}) {
+  return (
+    <div className="flex flex-col items-start gap-6">
+      <div className="flex justify-center gap-4">
+        <Badge
+          className={`cursor-pointer px-4 py-2 ${selectedFacility === "all" ? "bg-primary" : "bg-secondary"}`}
+          onClick={() => setSelectedFacility("all")}
+        >
+          All Facilities
+        </Badge>
+        {Array.from(facilities).map((facility) => (
+          <Badge
+            key={facility}
+            className={`cursor-pointer px-4 py-2 ${selectedFacility === facility ? "bg-primary" : "bg-secondary"}`}
+            onClick={() => setSelectedFacility(facility)}
+          >
+            {facility}
+          </Badge>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function CourtsAvailability({data}: CourtsAvailabilityProps) {
+  const [selectedFacility, setSelectedFacility] = useState<string>("all");
+
+  const facilities = new Set(data.flatMap((day) => day.locations.map((location) => location.name)));
+
+  return (
+    <>
+      <FacilitySelector
+        facilities={facilities}
+        selectedFacility={selectedFacility}
+        setSelectedFacility={setSelectedFacility}
+      />
+
+      {data.map((day) => (
+        <TabsContent key={formatDate(day.date)} className="w-full" value={formatDate(day.date)}>
+          <div className="grid w-full gap-6 md:grid-cols-2">
+            {day.locations
+              .filter(
+                (location) => location.name === selectedFacility || selectedFacility === "all",
+              )
+              .map((location) => (
+                <FacilityCard key={location.name} facility={location} />
+              ))}
+          </div>
+        </TabsContent>
+      ))}
+    </>
+  );
+}

--- a/src/app/availability/components/DayTabs/index.tsx
+++ b/src/app/availability/components/DayTabs/index.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import {Tabs} from "@/components/ui/tabs";
+
+export function DayTabs({
+  dateToDisplay,
+  children,
+}: {
+  dateToDisplay: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Tabs
+      defaultValue={dateToDisplay}
+      onValueChange={(value) => {
+        const searchParams = new URLSearchParams(window.location.search);
+
+        searchParams.set("date", value);
+
+        history.pushState(null, "", `/availability?${searchParams.toString()}`);
+      }}
+    >
+      {children}
+    </Tabs>
+  );
+}

--- a/src/app/availability/components/DayTabs/index.tsx
+++ b/src/app/availability/components/DayTabs/index.tsx
@@ -5,12 +5,15 @@ import {Tabs} from "@/components/ui/tabs";
 export function DayTabs({
   dateToDisplay,
   children,
+  className,
 }: {
   dateToDisplay: string;
   children: React.ReactNode;
+  className?: string;
 }) {
   return (
     <Tabs
+      className={className}
       defaultValue={dateToDisplay}
       onValueChange={(value) => {
         const searchParams = new URLSearchParams(window.location.search);

--- a/src/app/availability/components/FacilityCard/index.tsx
+++ b/src/app/availability/components/FacilityCard/index.tsx
@@ -1,0 +1,73 @@
+import {Calendar, Clock} from "lucide-react";
+
+import {Card, CardContent, CardHeader, CardTitle} from "@/components/ui/card";
+import {Badge} from "@/components/ui/badge";
+
+function getColorsForTime(time: string) {
+  const hour = parseInt(time.split(":")[0]);
+
+  // Morning (before 12PM)
+  if (hour < 12) {
+    return "bg-blue-900 text-blue-100";
+  }
+
+  // Afternoon (12-6PM)
+  if (hour >= 12 && hour < 18) {
+    return "bg-amber-900 text-amber-100";
+  }
+
+  // Evening (after 6PM)
+  return "bg-purple-900 text-purple-100";
+}
+
+function SlotBadge({slot}: {slot: string}) {
+  const colorClasses = getColorsForTime(slot);
+
+  return (
+    <Badge className={`flex items-center gap-1 ${colorClasses}`}>
+      <Clock className="h-3 w-3" />
+      {slot}
+    </Badge>
+  );
+}
+
+interface FacilityCardProps {
+  facility: {
+    name: string;
+    courts: {
+      name: string;
+      slots: string[];
+    }[];
+  };
+}
+
+export function FacilityCard({facility}: FacilityCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Calendar className="h-5 w-5" />
+          {facility.name}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col gap-4">
+          {facility.courts.map((court) => (
+            <div key={court.name} className="rounded-lg border border-gray-200 p-4">
+              <div className="flex flex-col gap-2">
+                <h3 className="font-medium">{court.name}</h3>
+                <div className="flex flex-wrap gap-2">
+                  {court.slots.length > 0 ? (
+                    court.slots.map((slot) => <SlotBadge key={slot} slot={slot} />)
+                  ) : (
+                    <p className="text-muted-foreground text-sm">No available slots</p>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/availability/layout.tsx
+++ b/src/app/availability/layout.tsx
@@ -1,0 +1,28 @@
+function Legend() {
+  return (
+    <div className="flex justify-center gap-4 text-sm">
+      <div className="flex items-center gap-2">
+        <div className="h-3 w-3 rounded-full bg-blue-500" />
+        <span>Morning (before 12PM)</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <div className="h-3 w-3 rounded-full bg-amber-500" />
+        <span>Afternoon (12-6PM)</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <div className="h-3 w-3 rounded-full bg-purple-500" />
+        <span>Evening (after 6PM)</span>
+      </div>
+    </div>
+  );
+}
+
+export default async function CourtsLayout({children}: {children: React.ReactNode}) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-6">
+      {children}
+
+      <Legend />
+    </div>
+  );
+}

--- a/src/app/availability/layout.tsx
+++ b/src/app/availability/layout.tsx
@@ -1,28 +1,3 @@
-function Legend() {
-  return (
-    <div className="flex justify-center gap-4 text-sm">
-      <div className="flex items-center gap-2">
-        <div className="h-3 w-3 rounded-full bg-blue-500" />
-        <span>Morning (before 12PM)</span>
-      </div>
-      <div className="flex items-center gap-2">
-        <div className="h-3 w-3 rounded-full bg-amber-500" />
-        <span>Afternoon (12-6PM)</span>
-      </div>
-      <div className="flex items-center gap-2">
-        <div className="h-3 w-3 rounded-full bg-purple-500" />
-        <span>Evening (after 6PM)</span>
-      </div>
-    </div>
-  );
-}
-
 export default async function CourtsLayout({children}: {children: React.ReactNode}) {
-  return (
-    <div className="flex flex-col items-center justify-center gap-6">
-      {children}
-
-      <Legend />
-    </div>
-  );
+  return <div className="flex flex-col items-center justify-start gap-6">{children}</div>;
 }

--- a/src/app/availability/page.tsx
+++ b/src/app/availability/page.tsx
@@ -14,23 +14,13 @@ import {getCourts} from "@/lib/atc";
  */
 const DAYS_TO_SHOW = 7;
 
-interface DaysListProps {
-  searchParams: Promise<{date: string}>;
-}
-
-async function DaysList({searchParams}: DaysListProps) {
+async function getAvailabilityData(today: Date) {
   "use cache";
 
   cacheLife("minutes");
   cacheTag("availability");
 
-  const {date: dateFromSearchParams} = await searchParams;
-
-  const today = new Date();
-
-  const dateToDisplay = formatDate(dateFromSearchParams ? new Date(dateFromSearchParams) : today);
-
-  const availabilityData = Promise.all(
+  return Promise.all(
     Array.from({length: DAYS_TO_SHOW}, async (_, i) => {
       const date = addDay(today, i);
       const formattedDate = formatDate(date);
@@ -45,6 +35,18 @@ async function DaysList({searchParams}: DaysListProps) {
       };
     }),
   );
+}
+
+interface DaysListProps {
+  searchParams: Promise<{date: string}>;
+}
+
+async function DaysList({searchParams}: DaysListProps) {
+  const {date: dateFromSearchParams} = await searchParams;
+
+  const today = new Date();
+
+  const dateToDisplay = formatDate(dateFromSearchParams ? new Date(dateFromSearchParams) : today);
 
   return (
     <DayTabs dateToDisplay={dateToDisplay}>
@@ -60,7 +62,7 @@ async function DaysList({searchParams}: DaysListProps) {
         })}
       </TabsList>
 
-      {availabilityData.then((data) => (
+      {getAvailabilityData(today).then((data) => (
         <CourtsAvailability data={data} />
       ))}
     </DayTabs>

--- a/src/app/availability/page.tsx
+++ b/src/app/availability/page.tsx
@@ -1,0 +1,64 @@
+import {Suspense} from "react";
+import {unstable_cacheLife as cacheLife, unstable_cacheTag as cacheTag} from "next/cache";
+
+import {CourtsAvailability} from "@/app/availability/components/CourtsAvailability";
+import {Tabs, TabsList, TabsTrigger} from "@/components/ui/tabs";
+import {addDay, formatDate, formatDateWithDay} from "@/lib/dates";
+import {getLocations} from "@/lib/dincy";
+import {getCourts} from "@/lib/atc";
+
+/**
+ * Show availability for today and the next 6 days
+ */
+const DAYS_TO_SHOW = 7;
+
+export default async function AvailabilityPage() {
+  "use cache";
+
+  cacheLife("minutes");
+  cacheTag("availability");
+
+  const today = new Date();
+
+  const availabilityData = Promise.all(
+    Array.from({length: DAYS_TO_SHOW}, async (_, i) => {
+      const date = addDay(today, i);
+      const formattedDate = formatDate(date);
+
+      const locations = await getLocations().then((locations) => {
+        return Promise.all(locations.map((location) => getCourts(location.id, formattedDate)));
+      });
+
+      return {
+        date,
+        locations,
+      };
+    }),
+  );
+
+  return (
+    <div className="flex min-h-screen w-full flex-col items-start gap-4">
+      <h1 className="text-center text-3xl font-bold">Disponibilidad</h1>
+
+      <Tabs className="flex w-full flex-col gap-6" defaultValue={formatDate(today)}>
+        <TabsList className="grid grid-cols-7">
+          {Array.from({length: DAYS_TO_SHOW}, (_, i) => {
+            const date = addDay(today, i);
+
+            return (
+              <TabsTrigger key={formatDate(date)} value={formatDate(date)}>
+                {formatDateWithDay(date)}
+              </TabsTrigger>
+            );
+          })}
+        </TabsList>
+
+        <Suspense fallback={<div className="text-center">Loading availability data...</div>}>
+          {availabilityData.then((data) => (
+            <CourtsAvailability data={data} />
+          ))}
+        </Suspense>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/app/availability/page.tsx
+++ b/src/app/availability/page.tsx
@@ -49,7 +49,7 @@ async function DaysList({searchParams}: DaysListProps) {
   const dateToDisplay = formatDate(dateFromSearchParams ? new Date(dateFromSearchParams) : today);
 
   return (
-    <DayTabs dateToDisplay={dateToDisplay}>
+    <DayTabs className="w-full" dateToDisplay={dateToDisplay}>
       <TabsList className="grid grid-cols-7">
         {Array.from({length: DAYS_TO_SHOW}, (_, i) => {
           const date = addDay(today, i);

--- a/src/app/availability/page.tsx
+++ b/src/app/availability/page.tsx
@@ -69,17 +69,38 @@ async function DaysList({searchParams}: DaysListProps) {
   );
 }
 
+function Legend() {
+  return (
+    <div className="flex justify-center gap-4 text-sm">
+      <div className="flex items-center gap-2">
+        <div className="h-3 w-3 rounded-full bg-blue-500" />
+        <span>Mañana (antes de las 12PM)</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <div className="h-3 w-3 rounded-full bg-amber-500" />
+        <span>Tarde (12-6PM)</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <div className="h-3 w-3 rounded-full bg-purple-500" />
+        <span>Noche (después de las 6PM)</span>
+      </div>
+    </div>
+  );
+}
+
 export default async function AvailabilityPage({
   searchParams,
 }: {
   searchParams: Promise<{date: string}>;
 }) {
   return (
-    <div className="flex min-h-screen w-full flex-col items-start gap-4">
+    <div className="flex w-full flex-col items-start justify-start gap-4">
       <h1 className="text-center text-3xl font-bold">Disponibilidad</h1>
 
-      <Suspense fallback={<div className="text-center">Loading availability data...</div>}>
+      <Suspense fallback={<div className="text-center">Cargando datos de disponibilidad...</div>}>
         <DaysList searchParams={searchParams} />
+
+        <Legend />
       </Suspense>
     </div>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,10 +1,10 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:is(.dark *));
+
 @plugin "tailwindcss-animate";
 
 :root {
-  --background: hsl(0 0% 100%);
-  --foreground: hsl(240 10% 3.9%);
 
   --card: hsl(0 0% 100%);
   --card-foreground: hsl(240 10% 3.9%);
@@ -34,12 +34,30 @@
   --chart-5: hsl(27 87% 67%);
 
   --radius: 0.6rem;
+
+  --background: oklch(1 0 0);
+
+  --foreground: oklch(0.145 0 0);
+
+  --sidebar: oklch(0.985 0 0);
+
+  --sidebar-foreground: oklch(0.145 0 0);
+
+  --sidebar-primary: oklch(0.205 0 0);
+
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+
+  --sidebar-accent: oklch(0.97 0 0);
+
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+
+  --sidebar-border: oklch(0.922 0 0);
+
+  --sidebar-ring: oklch(0.708 0 0);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: hsl(240 10% 3.9%);
-    --foreground: hsl(0 0% 98%);
 
     --card: hsl(240 10% 3.9%);
     --card-foreground: hsl(0 0% 98%);
@@ -105,6 +123,14 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
+  --color-sidebar-ring: var(--sidebar-ring);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar: var(--sidebar);
 }
 
 @layer base {
@@ -114,4 +140,69 @@
   body {
     @apply bg-background text-foreground;
   }
+}
+
+.dark {
+
+  --background: oklch(0.145 0 0);
+
+  --foreground: oklch(0.985 0 0);
+
+  --card: oklch(0.205 0 0);
+
+  --card-foreground: oklch(0.985 0 0);
+
+  --popover: oklch(0.205 0 0);
+
+  --popover-foreground: oklch(0.985 0 0);
+
+  --primary: oklch(0.922 0 0);
+
+  --primary-foreground: oklch(0.205 0 0);
+
+  --secondary: oklch(0.269 0 0);
+
+  --secondary-foreground: oklch(0.985 0 0);
+
+  --muted: oklch(0.269 0 0);
+
+  --muted-foreground: oklch(0.708 0 0);
+
+  --accent: oklch(0.269 0 0);
+
+  --accent-foreground: oklch(0.985 0 0);
+
+  --destructive: oklch(0.704 0.191 22.216);
+
+  --border: oklch(1 0 0 / 10%);
+
+  --input: oklch(1 0 0 / 15%);
+
+  --ring: oklch(0.556 0 0);
+
+  --chart-1: oklch(0.488 0.243 264.376);
+
+  --chart-2: oklch(0.696 0.17 162.48);
+
+  --chart-3: oklch(0.769 0.188 70.08);
+
+  --chart-4: oklch(0.627 0.265 303.9);
+
+  --chart-5: oklch(0.645 0.246 16.439);
+
+  --sidebar: oklch(0.205 0 0);
+
+  --sidebar-foreground: oklch(0.985 0 0);
+
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+
+  --sidebar-accent: oklch(0.269 0 0);
+
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+
+  --sidebar-border: oklch(1 0 0 / 10%);
+
+  --sidebar-ring: oklch(0.556 0 0);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 
 export default async function RootLayout({children}: {children: React.ReactNode}) {
   return (
-    <html lang="en">
+    <html className="dark" lang="en">
       <body className="container m-auto grid min-h-screen grid-rows-[auto_1fr_auto] gap-8 px-4 font-sans antialiased">
         <header className="text-xl leading-[4rem] font-bold">
           <Link href="/">Fulboncy</Link>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,3 @@
+import AvailabilityPage from "./availability/page";
+
+export default AvailabilityPage;

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import {Slot} from "@radix-ui/react-slot";
+import {cva, type VariantProps} from "class-variance-authority";
+
+import {cn} from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline: "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> & VariantProps<typeof badgeVariants> & {asChild?: boolean}) {
+  const Comp = asChild ? Slot : "span";
+
+  return <Comp className={cn(badgeVariants({variant}), className)} data-slot="badge" {...props} />;
+}
+
+export {Badge, badgeVariants};

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+
+import {cn} from "@/lib/utils";
+
+function Card({className, ...props}: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className,
+      )}
+      data-slot="card"
+      {...props}
+    />
+  );
+}
+
+function CardHeader({className, ...props}: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className,
+      )}
+      data-slot="card-header"
+      {...props}
+    />
+  );
+}
+
+function CardTitle({className, ...props}: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("leading-none font-semibold", className)}
+      data-slot="card-title"
+      {...props}
+    />
+  );
+}
+
+function CardDescription({className, ...props}: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("text-muted-foreground text-sm", className)}
+      data-slot="card-description"
+      {...props}
+    />
+  );
+}
+
+function CardAction({className, ...props}: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("col-start-2 row-span-2 row-start-1 self-start justify-self-end", className)}
+      data-slot="card-action"
+      {...props}
+    />
+  );
+}
+
+function CardContent({className, ...props}: React.ComponentProps<"div">) {
+  return <div className={cn("px-6", className)} data-slot="card-content" {...props} />;
+}
+
+function CardFooter({className, ...props}: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      data-slot="card-footer"
+      {...props}
+    />
+  );
+}
+
+export {Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent};

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+
+import {cn} from "@/lib/utils";
+
+function Label({className, ...props}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className,
+      )}
+      data-slot="label"
+      {...props}
+    />
+  );
+}
+
+export {Label};

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import * as React from "react";
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import {CircleIcon} from "lucide-react";
+
+import {cn} from "@/lib/utils";
+
+function RadioGroup({className, ...props}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      className={cn("grid gap-3", className)}
+      data-slot="radio-group"
+      {...props}
+    />
+  );
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      className={cn(
+        "border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      data-slot="radio-group-item"
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        className="relative flex items-center justify-center"
+        data-slot="radio-group-indicator"
+      >
+        <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  );
+}
+
+export {RadioGroup, RadioGroupItem};

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+
+import {cn} from "@/lib/utils";
+
+function Tabs({className, ...props}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      className={cn("flex flex-col gap-2", className)}
+      data-slot="tabs"
+      {...props}
+    />
+  );
+}
+
+function TabsList({className, ...props}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      className={cn(
+        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        className,
+      )}
+      data-slot="tabs-list"
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({className, ...props}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      className={cn(
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      data-slot="tabs-trigger"
+      {...props}
+    />
+  );
+}
+
+function TabsContent({className, ...props}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      className={cn("flex-1 outline-none", className)}
+      data-slot="tabs-content"
+      {...props}
+    />
+  );
+}
+
+export {Tabs, TabsList, TabsTrigger, TabsContent};

--- a/src/lib/atc.ts
+++ b/src/lib/atc.ts
@@ -1,4 +1,4 @@
-import {format} from "@formkit/tempo";
+import {formatTime} from "./dates";
 
 type CourtAvailability = {
   id: string;
@@ -73,11 +73,7 @@ export async function getCourts(field: string, date: string) {
 
   for (const court of data.available_courts) {
     for (const slot of court.available_slots) {
-      const slotStart = format({
-        date: new Date(slot.start),
-        format: "HH:mm",
-        tz: "America/Argentina/Buenos_Aires",
-      });
+      const slotStart = formatTime(new Date(slot.start));
 
       // Initialize the court if it doesn't exist
       if (!availableTimes[court.id]) {
@@ -98,3 +94,5 @@ export async function getCourts(field: string, date: string) {
     courts: Object.values(availableTimes),
   };
 }
+
+export type LocationWithCourts = Awaited<ReturnType<typeof getCourts>>;

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -16,7 +16,7 @@ export function formatDate(date: Date) {
   return format({
     date: date,
     format: "YYYY-MM-DD",
-    tz: TIMEZONE,
+    tz: "UTC",
   });
 }
 
@@ -24,6 +24,6 @@ export function formatDateWithDay(date: Date) {
   return format({
     date: date,
     format: "ddd, DD",
-    tz: TIMEZONE,
+    tz: "UTC",
   });
 }

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -1,0 +1,29 @@
+import {format} from "@formkit/tempo";
+
+export {addDay} from "@formkit/tempo";
+
+const TIMEZONE = "America/Argentina/Buenos_Aires";
+
+export function formatTime(date: Date) {
+  return format({
+    date: date,
+    format: "HH:mm",
+    tz: TIMEZONE,
+  });
+}
+
+export function formatDate(date: Date) {
+  return format({
+    date: date,
+    format: "YYYY-MM-DD",
+    tz: TIMEZONE,
+  });
+}
+
+export function formatDateWithDay(date: Date) {
+  return format({
+    date: date,
+    format: "ddd, DD",
+    tz: TIMEZONE,
+  });
+}

--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -1,6 +1,6 @@
 import nacl from "tweetnacl";
 
-export type DiscordInteraction = {
+type DiscordInteraction = {
   type: number; // 1 = PING, 2 = APPLICATION_COMMAND, etc.
   id: string; // ID de la interacción
   application_id: string; // ID de la aplicación (bot)

--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -1,6 +1,6 @@
 import nacl from "tweetnacl";
 
-type DiscordInteraction = {
+export type DiscordInteraction = {
   type: number; // 1 = PING, 2 = APPLICATION_COMMAND, etc.
   id: string; // ID de la interacción
   application_id: string; // ID de la aplicación (bot)

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import {clsx, type ClassValue} from "clsx";
+import {twMerge} from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
This PR introduces the new `/availability` page, allowing users to view court availability across different facilities for the next 7 days.

It can be tested [here](https://fulboncy-santi.vercel.app/availability)

### Main Changes

- Adds shadcn config
- Adds the following shadcn components: `badge`, `card`, `tabs`, `radio-group`, `label`
- Creates the `/availability` page, it fetches and caches (`cacheLife: "minutes"`) court availability data for the next 7 days
- Selected date and facility filters are synchronized with url search parameters (I plan to change them to dynamic route params in a follow-up PR)